### PR TITLE
Fix psp2/power.h location

### DIFF
--- a/src/PSP.h
+++ b/src/PSP.h
@@ -13,7 +13,7 @@ extern "C" {
 
 #include <psp2/types.h>
 #include <psp2/ctrl.h>
-#include <Psp2/power.h>
+#include <psp2/power.h>
 #include <psp2/touch.h>
 #include <psp2/io/fcntl.h>
 #include <psp2/moduleinfo.h>


### PR DESCRIPTION
I was getting:

```
src/PSP.h:16:24: fatal error: Psp2/power.h: No such file or directory
 #include <Psp2/power.h>
```

And the location is actually `psp2/power.h` like the other lines.
