### PR TITLE
Enable sound and analog stick

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ $(PROJECT).vpk: eboot.bin param.sfo
 	out/$(PROJECT).vpk
 
 TEST_OUTPUT = bin/*.S out/$(PROJECT).elf out/$(PROJECT).velf bin/*.o lib/*.a lib/*.o lib/*.S # lib/Makefile
-LIBS = -lvita2d -lm -lSceLibKernel_stub -lSceTouch_stub -lSceDisplay_stub -lSceGxm_stub -lSceCtrl_stub -lSceRtc_stub -lScePower_stub -lSceSysmodule_stub -lSceCommonDialog_stub
+LIBS = -lvita2d -lm -lSceLibKernel_stub -lSceTouch_stub -lSceDisplay_stub -lSceGxm_stub -lSceCtrl_stub -lSceRtc_stub -lScePower_stub -lSceSysmodule_stub -lSceCommonDialog_stub -lSceAudio_stub
 
 debugnet: CFLAGS += -DUSE_DEBUGNET -g
 debugnet: LIBS := -ldebugnet -lSceNet_stub -lSceNetCtl_stub $(LIBS)

--- a/src/i_main.c
+++ b/src/i_main.c
@@ -63,6 +63,7 @@ int				cbuf_curpos[MAXDEPTH];
 int				now_depth;
 char			buf[BUFSIZE];
 int				screen_res;
+boolean			analog_enabled;
 
 int debug_res = 0x0;
 
@@ -98,6 +99,7 @@ int main(int argc, char** argv)
 	//sceCtrlSetSamplingCycle(0);
 
 	sceCtrlSetSamplingMode(SCE_CTRL_MODE_ANALOG);
+	analog_enabled = 0;
 
 	//SetupCallbacks();
         screen_res = DEFAULT_SCREEN_SCALE;
@@ -348,6 +350,16 @@ void Draw_All(void) {
             break;
     }
 
+    // Controller mode
+    if (analog_enabled)
+    {
+        mh_print(0, 450, "Controller Mode (press triangle to change): Analog Stick", rgb2col(255, 255, 0), 0, 0);
+    }
+    else
+    {
+        mh_print(0, 450, "Controller Mode (press triangle to change): D-Pad", rgb2col(255, 255, 0), 0, 0);
+    }
+
     if (dlist_num == 0)
     {
         mh_print(32, 40, "No WADs found... Put WADs in:", rgb2col(255, 0, 0), 0, 0);
@@ -489,6 +501,9 @@ int Control(void) {
 	if (new_pad & SCE_CTRL_SELECT) {
 		Change_Resolution();
 	}
+	if (new_pad & SCE_CTRL_TRIANGLE) {
+		Change_Controller_Mode();
+	}
 	
 	return 0;
 }
@@ -513,4 +528,14 @@ void Change_Resolution()
 			break;
 	}
 	pgInit(screen_res);
+}
+
+void Change_Controller_Mode()
+{
+	if (analog_enabled) {
+		analog_enabled = 0;
+	} else {
+		analog_enabled = 1;
+	}
+	I_SetControlMode(analog_enabled);
 }

--- a/src/i_main.c
+++ b/src/i_main.c
@@ -97,11 +97,7 @@ int main(int argc, char** argv)
 
 	//sceCtrlSetSamplingCycle(0);
 
-	//int result = sceCtrlSetSamplingMode(SCE_CTRL_MODE_ANALOG);
- //   if (result < 0)
- //   {
- //       printf("sceCtrlSetSamplingMode : 0x%x", result);
- //   }
+	sceCtrlSetSamplingMode(SCE_CTRL_MODE_ANALOG);
 
 	//SetupCallbacks();
         screen_res = DEFAULT_SCREEN_SCALE;

--- a/src/i_main.c
+++ b/src/i_main.c
@@ -536,6 +536,6 @@ void Vita_Audio_Thread() {
 void Vita_Audio_Init()
 {
 	SceUID thid;
-	thid = sceKernelCreateThread("audio_thread", &Vita_Audio_Thread, 0x10000100, SCE_AUDIO_MAX_LEN*32, 0, 0, NULL);
+	thid = sceKernelCreateThread("audio_thread", &Vita_Audio_Thread, 0x10000100, SCE_AUDIO_MAX_LEN*4, 0, 0, NULL);
 	sceKernelStartThread(thid, 0, NULL);
 }

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -515,7 +515,7 @@ void I_GetEvent()
 		}
 
 		if (!analog) {
-		if (ctl.ly <= 0x10)
+		if (ctl.ry <= 0x10)
 		{
             looped = false;
 
@@ -551,7 +551,7 @@ void I_GetEvent()
 			kbevent.data1 = KEY_1 + num;
 			D_PostEvent(&kbevent);
 		}
-		if (ctl.ly >= 0xD0)
+		if (ctl.ry >= 0xD0)
 		{
             looped = false;
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1280,3 +1280,7 @@ void I_FinishUpdate2 () {
 
 	//sceGuDisplay(GU_TRUE);
 }
+
+void I_SetControlMode(boolean isAnalog) {
+	analog = isAnalog;
+}

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -434,8 +434,6 @@ void I_GetEvent()
 
 	if (gamestate == GS_LEVEL)
 	{
-        boolean looped = false;
-
 		plyrweap = &players[consoleplayer];
 
 		num = plyrweap->readyweapon;
@@ -445,21 +443,12 @@ void I_GetEvent()
 		
 		if (key & SCE_CTRL_UP)
 		{
-            looped = false;
-
 			while (1)
             {
 				++num;
                 if (num > wp_supershotgun)
                 {
-                    if (looped)
-                    {
-                        num = plyrweap->readyweapon;
-                        break;
-                    }
-
                     num = wp_fist;
-                    looped = true;
                 }
 
 				if (plyrweap->weaponowned[num])
@@ -470,10 +459,6 @@ void I_GetEvent()
 
 				
 			}
-
-		kbevent.type = ev_keydown;
-		kbevent.data1 = KEY_1 + num;
-		D_PostEvent(&kbevent);
 		}
 		else  
 		{
@@ -485,21 +470,12 @@ void I_GetEvent()
 		
 		if (key & SCE_CTRL_DOWN)
         {
-            looped = false;
-
 			while (1)
             {
 				--num;
                 if (num == -1)
                 {
-                    if (looped)
-                    {
-                        num = plyrweap->readyweapon;
-                        break;
-                    }
-
                     num = wp_supershotgun;
-                    looped = true;
                 }
 				if (plyrweap->weaponowned[num])
 				{
@@ -507,31 +483,18 @@ void I_GetEvent()
 					break;
 				}
 			}
-
-			kbevent.type = ev_keydown;
-			kbevent.data1 = KEY_1 + num;
-			D_PostEvent(&kbevent);
 		}
 		}
 
 		if (!analog) {
 		if (ctl.ry <= 0x10)
 		{
-            looped = false;
-
 			while (1)
             {
 				++num;
 				if (num > wp_supershotgun)
                 {
-                    if (looped)
-                    {
-                        num = plyrweap->readyweapon;
-                        break;
-                    }
-
                     num = wp_fist;
-                    looped = true;
                 }
 
 				if (plyrweap->weaponowned[num])
@@ -540,10 +503,6 @@ void I_GetEvent()
 					break;
 				}
 			}
-
-			kbevent.type = ev_keydown;
-			kbevent.data1 = KEY_1 + num;
-			D_PostEvent(&kbevent);
 		}
 		else  
         {
@@ -553,21 +512,12 @@ void I_GetEvent()
 		}
 		if (ctl.ry >= 0xD0)
 		{
-            looped = false;
-
 			while (1)
             {
                 --num;
                 if (num == -1)
                 {
-                    if (looped)
-                    {
-                        num = plyrweap->readyweapon;
-                        break;
-                    }
-
                     num = wp_supershotgun;
-                    looped = true;
                 }
 
 				if (plyrweap->weaponowned[num])
@@ -576,10 +526,6 @@ void I_GetEvent()
 					break;
 				}
 			}
-
-			kbevent.type = ev_keydown;
-			kbevent.data1 = KEY_1 + num;
-			D_PostEvent(&kbevent);
 		}
         }
     }


### PR DESCRIPTION
PR includes the following changes
- Enable SoundFX (still no music)
- Fix weapon switching by enabling analog stick
- Move the weapon switching to the right analog stick
- Add option for toggling between d-pad controls and analog control at main menu